### PR TITLE
CVS-120 Nodeのバージョンを指定

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+engine-strict=true

--- a/package.json
+++ b/package.json
@@ -1,6 +1,9 @@
 {
   "name": "char-v-frontend",
   "version": "0.1.0",
+  "engines" : {
+    "node" : ">=16.0.0 <17.0.0"
+  },
   "browserslist": {
     "production": [
       ">0.2%",


### PR DESCRIPTION
16.0.0 以上 17.0.0 未満でないと動かないようにした

```
$ node -v
v19.0.0

$ yarn install
yarn install v1.22.19
[1/5] Validating package.json...
error char-v-frontend@0.1.0: The engine "node" is incompatible with this module. Expected version ">=16.0.0 <17.0.0". Got "19.0.0"
error Found incompatible module.
info Visit https://yarnpkg.com/en/docs/cli/install for documentation about this command.
```
