### PR TITLE
CVS-246 効いてないeslintルールを効くようにする

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,102 +1,114 @@
 module.exports = {
   env: {
     browser: true,
-    es2021: true
+    es2021: true,
   },
-  extends: ["plugin:react/recommended", "airbnb", "airbnb/hooks", "plugin:@typescript-eslint/recommended", "plugin:@typescript-eslint/recommended-requiring-type-checking", "prettier", "plugin:storybook/recommended", "plugin:jsx-a11y/recommended"],
-  overrides: [{
-    files: ['**/__tests__/**/*.+(ts|tsx|js)', '**/?(*.)+(spec|test).+(ts|tsx|js)'],
-    extends: ['plugin:jest-dom/recommended', 'plugin:testing-library/react']
-  }],
-  parser: "@typescript-eslint/parser",
+  extends: [
+    'plugin:react/recommended',
+    'airbnb',
+    'airbnb/hooks',
+    'plugin:@typescript-eslint/recommended',
+    'plugin:@typescript-eslint/recommended-requiring-type-checking',
+    'prettier',
+    'plugin:storybook/recommended',
+    'plugin:jsx-a11y/recommended',
+  ],
+  overrides: [
+    {
+      files: ['**/__tests__/**/*.+(ts|tsx|js)', '**/?(*.)+(spec|test).+(ts|tsx|js)'],
+      extends: ['plugin:jest-dom/recommended', 'plugin:testing-library/react'],
+    },
+  ],
+  parser: '@typescript-eslint/parser',
   parserOptions: {
     ecmaFeatures: {
-      jsx: true
+      jsx: true,
     },
-    ecmaVersion: "latest",
-    sourceType: "module",
+    ecmaVersion: 'latest',
+    sourceType: 'module',
     tsconfigRootDir: __dirname,
-    project: ["./tsconfig.json"]
+    project: ['./tsconfig.json'],
   },
-  plugins: ["react", "@typescript-eslint", "unused-imports", "jest-dom", "testing-library", "jsx-a11y", "deprecation"],
-  ignorePatterns: [".eslintrc.js", "vite.config.ts", "vitest.setup.ts", "squoosh.ts"],
+  plugins: ['react', '@typescript-eslint', 'unused-imports', 'jest-dom', 'testing-library', 'jsx-a11y', 'deprecation'],
+  ignorePatterns: ['.eslintrc.js', 'vite.config.ts', 'vitest.setup.ts', 'squoosh.ts'],
   rules: {
-    "no-use-before-define": "off",
-    "no-unused-vars": "off",
-    "@typescript-eslint/no-unused-vars": "off",
-    "@typescript-eslint/no-use-before-define": "off",
-    "import/prefer-default-export": "off",
-    "import/extensions": ["error", {
-      js: "never",
-      jsx: "never",
-      ts: "never",
-      tsx: "never"
-    }],
-    "import/order": ["error", {
-      "groups": ["builtin", "external", "internal", "parent", "sibling", "object", "type", "index"],
-      "newlines-between": "always",
-      "pathGroupsExcludedImportTypes": ["builtin", "object"],
-      "alphabetize": {
-        "order": "asc",
-        "caseInsensitive": true
-      },
-      "pathGroups": [{
-        "pattern": "@src/**",
-        "group": "parent",
-        "position": "before"
-      }],
-    }],
-    "react/jsx-filename-extension": ["error", {
-      extensions: [".jsx", ".tsx"]
-    }],
-    "react/react-in-jsx-scope": "off",
-    "no-void": ["error", {
-      allowAsStatement: true
-    }],
-    "unused-imports/no-unused-imports": "error",
-    "unused-imports/no-unused-vars": ["warn", {
-      "vars": "all",
-      "varsIgnorePattern": "^_",
-      "args": "after-used",
-      "argsIgnorePattern": "^_"
-    }],
-    "react/function-component-definition": [
-      2,
-      { "namedComponents": "arrow-function" }
-    ],
-    "react/require-default-props": [
-      0,
-    ],
-    "react/jsx-props-no-spreading": [
-      0,
-    ],
-    "@typescript-eslint/no-misused-promises": [
-      "error",
-      { "checksVoidReturn": { "attributes": false } }
-    ],
-    "import/no-extraneous-dependencies": [
-      "error",
+    'no-use-before-define': 'off',
+    'no-unused-vars': 'off',
+    '@typescript-eslint/no-unused-vars': 'off',
+    '@typescript-eslint/no-use-before-define': 'off',
+    'import/prefer-default-export': 'off',
+    'import/extensions': [
+      'error',
       {
-        "devDependencies": [
-          "**/*.stories.*",
-          "**/.storybook/**/*.*",
-          "**/*.spec.*"
+        js: 'never',
+        jsx: 'never',
+        ts: 'never',
+        tsx: 'never',
+      },
+    ],
+    'import/order': [
+      'error',
+      {
+        groups: ['builtin', 'external', 'internal', 'parent', 'sibling', 'object', 'type', 'index'],
+        'newlines-between': 'always',
+        pathGroupsExcludedImportTypes: ['builtin', 'object'],
+        alphabetize: {
+          order: 'asc',
+          caseInsensitive: true,
+        },
+        pathGroups: [
+          {
+            pattern: '@src/**',
+            group: 'parent',
+            position: 'before',
+          },
         ],
-        "peerDependencies": true
-      }
+      },
     ],
-    "no-underscore-dangle": [
-      0
+    'react/jsx-filename-extension': [
+      'error',
+      {
+        extensions: ['.jsx', '.tsx'],
+      },
     ],
-    "deprecation/deprecation": "error"
+    'react/react-in-jsx-scope': 'off',
+    'no-void': [
+      'error',
+      {
+        allowAsStatement: true,
+      },
+    ],
+    'unused-imports/no-unused-imports': 'error',
+    'unused-imports/no-unused-vars': [
+      'warn',
+      {
+        vars: 'all',
+        varsIgnorePattern: '^_',
+        args: 'after-used',
+        argsIgnorePattern: '^_',
+      },
+    ],
+    'react/function-component-definition': [2, { namedComponents: 'arrow-function' }],
+    'react/require-default-props': [0],
+    'react/jsx-props-no-spreading': [0],
+    '@typescript-eslint/no-misused-promises': ['error', { checksVoidReturn: { attributes: false } }],
+    'import/no-extraneous-dependencies': [
+      'error',
+      {
+        devDependencies: ['**/*.stories.*', '**/.storybook/**/*.*', '**/*.spec.*'],
+        peerDependencies: true,
+      },
+    ],
+    'no-underscore-dangle': [0],
+    'deprecation/deprecation': 'error',
   },
   settings: {
     'import/resolver': {
       node: {
         paths: ['src'],
-        extensions: ['.js', '.jsx', '.ts', '.tsx']
+        extensions: ['.js', '.jsx', '.ts', '.tsx'],
       },
-      typescript: {}
-    }
-  }
+      typescript: {},
+    },
+  },
 };

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -44,7 +44,7 @@ module.exports = {
         "pattern": "@src/**",
         "group": "parent",
         "position": "before"
-      }]
+      }],
     }],
     "react/jsx-filename-extension": ["error", {
       extensions: [".jsx", ".tsx"]
@@ -87,7 +87,8 @@ module.exports = {
     ],
     "no-underscore-dangle": [
       0
-    ]
+    ],
+    "deprecation/deprecation": "error"
   },
   settings: {
     'import/resolver': {

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,8 +1,6 @@
 build/
 public/
 **/node_modules/
-*.config.js
-.*lintrc.js
 *.md
 coverage/*
 storybook-static/


### PR DESCRIPTION
## 概要

ついでにeslintの設定ファイルにprettierが効くようにする

## 動作テスト方法


## チェックリスト

- [x] [Contributing Guidelines](CONTRIBUTING.md) に従っている
- [x] PR に Labels がついている
- [x] PR タイトルに Jira の課題キー（CVS-*）がついている
